### PR TITLE
Powerspectrum requires lc object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,5 +49,5 @@ Copyright
 All content © 2015 the authors. The code is distributed under the MIT license.
 
 Pull requests are welcome! If you are interested in the further development of
-Stingray, please `get in touch via the issues
+this project, please `get in touch via the issues
 <https://github.com/dhuppenkothen/stingray/issues>`_!

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Test suite
 
 Try::
 
-   $ nostests
+   $ nosetests
 
 Copyright
 ---------

--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -52,6 +52,12 @@ class Lightcurve(object):
 
         """
 
+        assert np.all(np.isfinite(time)), "There are inf or NaN values in " \
+                                            "your time array!"
+
+        assert np.all(np.isfinite(counts)), "There are inf or NaN values in " \
+                                            "your counts array!"
+
         self.time = np.asarray(time)
         self.counts = np.asarray(counts)
         self.ncounts = self.counts.shape[0]

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -331,7 +331,10 @@ class AveragedPowerspectrum(Powerspectrum):
             The light curve data to be Fourier-transformed.
 
         segment_size: float
-            The seize of each segment to
+            The size of each segment to average. Note that if the total duration
+            of each Lightcurve object in lc is not an integer multiple of the
+            segment_size, then any fraction left-over at the end of the
+            time series will be lost.
 
         norm: {"leahy" | "rms"}, optional, default "rms"
             The normaliation of the periodogram to be used. Options are
@@ -366,6 +369,15 @@ class AveragedPowerspectrum(Powerspectrum):
         """
 
 
+        ## make sure my inputs work!
+        assert isinstance(lc, lightcurve.Lightcurve), \
+                        "lc must be a lightcurve.Lightcurve object!"
+
+        assert norm in ["rms", "leahy"], \
+                        "norm must be either 'rms' or 'leahy'!"
+
+        assert np.isfinite(segment_size), "segment_size must be finite!"
+
         self.norm = norm
         self.segment_size = segment_size
 
@@ -388,7 +400,7 @@ class AveragedPowerspectrum(Powerspectrum):
             counts = lc.counts[start_ind:end_ind]
             lc_seg = lightcurve.Lightcurve(time, counts)
             ps_seg = Powerspectrum(lc_seg, norm=self.norm)
-            ps_all.append(ps)
+            ps_all.append(ps_seg)
             nphots_all.append(np.sum(lc_seg.counts))
             start_ind += nbins
             end_ind += nbins
@@ -412,7 +424,7 @@ class AveragedPowerspectrum(Powerspectrum):
 
             ps_all = np.hstack(ps_all)
             nphots_all = np.hstack(nphots_all)
-            
+
         m = len(ps_all)
         nphots = np.mean(nphots_all)
         ps_avg = np.zeros_like(ps_all[0].ps)

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -12,7 +12,7 @@ import stingray.utils as utils
 
 class Powerspectrum(object):
 
-    def __init__(self, lc = None, time = None, counts = None, norm='rms'):
+    def __init__(self, lc=None, norm='rms'):
         """
         Make a Periodogram (power spectrum) from a (binned) light curve.
         Periodograms can be Leahy normalized or fractional rms normalized.
@@ -24,14 +24,6 @@ class Powerspectrum(object):
         ----------
         lc: lightcurve.Lightcurve object, optional, default None
             The light curve data to be Fourier-transformed.
-
-        time: iterable, optional, default None
-            If lc is None, then this argument should contain a list of time
-            stamps of light curve bins
-
-        counts: iterable, optional, default None
-            If lc is None, this argument should contain a list of **counts per
-            bin** corresponding to the timestamps in *time*.
 
         norm: {"leahy" | "rms"}, optional, default "rms"
             The normaliation of the periodogram to be used. Options are
@@ -68,9 +60,7 @@ class Powerspectrum(object):
 
         ## check if input data is a Lightcurve object, if not make one or
         ## make an empty Periodogram object if lc == time == counts == None
-        if lc is None and time is not None and counts is not None:
-            lc = lightcurve.Lightcurve(time, counts=counts)
-        elif lc is not None:
+        if lc is not None:
             pass
         else:
             self.freq = None
@@ -329,26 +319,18 @@ class Powerspectrum(object):
 
 class AveragedPowerspectrum(Powerspectrum):
 
-    def __init__(self, lc=None, time=None, counts=None, segment_size=10.0,
-                norm="leahy"):
+    def __init__(self, lc, segment_size, norm="rms"):
         """
         Make an averaged periodogram from a light curve by segmenting the light
         curve, Fourier-transforming each segment and then averaging the
         resulting periodograms.
         Parameters
         ----------
-        lc: lightcurve.Lightcurve object, optional, default None
+        lc: lightcurve.Lightcurve object OR
+            iterable of lightcurve.Lightcurve objects
             The light curve data to be Fourier-transformed.
 
-        time: iterable, optional, default None
-            If lc is None, then this argument should contain a list of time
-            stamps of light curve bins
-
-        counts: iterable, optional, default None
-            If lc is None, this argument should contain a list of **counts per
-            bin** corresponding to the timestamps in *time*.
-
-        segment_size: float, optional, default 10
+        segment_size: float
             The seize of each segment to
 
         norm: {"leahy" | "rms"}, optional, default "rms"
@@ -387,15 +369,14 @@ class AveragedPowerspectrum(Powerspectrum):
         self.norm = norm
         self.segment_size = segment_size
 
-        Powerspectrum.__init__(lc, time, counts, norm)
+        Powerspectrum.__init__(self, lc, norm)
 
         return
 
 
-    def _make_powerspectrum(self, lc):
-
+    def _make_segment_psd(self, lc, segment_size):
         ## number of bins per segment
-        nbins = int(self.segment_size/lc.dt)
+        nbins = int(segment_size/lc.dt)
 
         start_ind = 0
         end_ind = nbins
@@ -406,12 +387,32 @@ class AveragedPowerspectrum(Powerspectrum):
             time = lc.time[start_ind:end_ind]
             counts = lc.counts[start_ind:end_ind]
             lc_seg = lightcurve.Lightcurve(time, counts)
-            ps = Powerspectrum(lc_seg, norm=self.norm)
+            ps_seg = Powerspectrum(lc_seg, norm=self.norm)
             ps_all.append(ps)
             nphots_all.append(np.sum(lc_seg.counts))
             start_ind += nbins
             end_ind += nbins
 
+        return ps_all, nphots_all
+
+    def _make_powerspectrum(self, lc):
+
+        ## chop light curves into segments
+        if isinstance(lc, lightcurve.Lightcurve):
+            ps_all, nphots_all = self._make_segment_psd(lc,
+                                                        self.segment_size)
+        else:
+            ps_all, nphots_all = [], []
+            for lc_seg in lc:
+                ps_sep, nphots_sep = self._make_segment_psd(lc_seg,
+                                                            self.segment_size)
+
+                ps_all.append(ps_sep)
+                nphots_all.append(nphots_sep)
+
+            ps_all = np.hstack(ps_all)
+            nphots_all = np.hstack(nphots_all)
+            
         m = len(ps_all)
         nphots = np.mean(nphots_all)
         ps_avg = np.zeros_like(ps_all[0].ps)

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -56,7 +56,6 @@ class Powerspectrum(object):
 
 
         """
-        print(norm)
         assert isinstance(norm, str), "norm is not a string!"
 
         assert norm.lower() in ["rms", "leahy"], \
@@ -392,8 +391,10 @@ class AveragedPowerspectrum(Powerspectrum):
 
 
     def _make_segment_psd(self, lc, segment_size):
+
+        assert isinstance(lc, lightcurve.Lightcurve)
+
         ## number of bins per segment
-        print(lc)
         nbins = int(segment_size/lc.dt)
 
         start_ind = 0

--- a/stingray/powerspectrum.py
+++ b/stingray/powerspectrum.py
@@ -56,7 +56,13 @@ class Powerspectrum(object):
 
 
         """
-        self.norm = norm
+        print(norm)
+        assert isinstance(norm, str), "norm is not a string!"
+
+        assert norm.lower() in ["rms", "leahy"], \
+                "norm must be either 'rms' or 'leahy'!"
+
+        self.norm = norm.lower()
 
         ## check if input data is a Lightcurve object, if not make one or
         ## make an empty Periodogram object if lc == time == counts == None
@@ -74,6 +80,12 @@ class Powerspectrum(object):
         self._make_powerspectrum(lc)
 
     def _make_powerspectrum(self, lc):
+
+        ## make sure my inputs work!
+        assert isinstance(lc, lightcurve.Lightcurve), \
+                        "lc must be a lightcurve.Lightcurve object!"
+
+
         ## total number of photons is the sum of the
         ## counts in the light curve
         self.nphots = np.sum(lc.counts)
@@ -369,16 +381,9 @@ class AveragedPowerspectrum(Powerspectrum):
         """
 
 
-        ## make sure my inputs work!
-        assert isinstance(lc, lightcurve.Lightcurve), \
-                        "lc must be a lightcurve.Lightcurve object!"
-
-        assert norm in ["rms", "leahy"], \
-                        "norm must be either 'rms' or 'leahy'!"
-
         assert np.isfinite(segment_size), "segment_size must be finite!"
 
-        self.norm = norm
+        self.norm = norm.lower()
         self.segment_size = segment_size
 
         Powerspectrum.__init__(self, lc, norm)
@@ -388,6 +393,7 @@ class AveragedPowerspectrum(Powerspectrum):
 
     def _make_segment_psd(self, lc, segment_size):
         ## number of bins per segment
+        print(lc)
         nbins = int(segment_size/lc.dt)
 
         start_ind = 0

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1,5 +1,8 @@
 
 import numpy as np
+
+from nose.tools import raises
+
 from stingray import Lightcurve
 
 np.random.seed(20150907)
@@ -72,6 +75,32 @@ class TestLightcurve(object):
         counts = np.zeros_like(times) + mean_counts
         lc = Lightcurve(times, counts)
         assert np.allclose(lc.countrate, np.zeros_like(counts)+mean_counts/dt)
+
+
+    @raises(TypeError)
+    def test_init_with_none_data(self):
+        dt = 0.5
+        mean_counts = 2.0
+        times = np.arange(0+dt/2.,5-dt/2., dt)
+        counts = np.array([None for i in xrange(times.shape[0])])
+        lc = Lightcurve(times, counts)
+
+    @raises(AssertionError)
+    def test_init_with_inf_data(self):
+        dt = 0.5
+        mean_counts = 2.0
+        times = np.arange(0+dt/2.,5-dt/2., dt)
+        counts = np.array([np.inf for i in xrange(times.shape[0])])
+        lc = Lightcurve(times, counts)
+
+    @raises(AssertionError)
+    def test_init_with_nan_data(self):
+        dt = 0.5
+        mean_counts = 2.0
+        times = np.arange(0+dt/2.,5-dt/2., dt)
+        counts = np.array([np.nan for i in xrange(times.shape[0])])
+        lc = Lightcurve(times, counts)
+
 
 class TestLightcurveRebin(object):
 

--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -210,11 +210,15 @@ class TestAveragedPowerspectrum(object):
         ps = AveragedPowerspectrum(self.lc, segment_size)
         assert np.isclose(ps.segment_size, segment_size)
 
-    def test_two_segments(self):
-        segment_size = self.lc.tseg/2.
+    def test_n_segments(self):
+        nseg_all = [1,2,3,5,10,20,100]
+        for nseg in nseg_all:
+            yield self.check_segment_size, nseg
+
+    def check_segment_size(self, nseg):
+        segment_size = self.lc.tseg/nseg
         ps = AveragedPowerspectrum(self.lc, segment_size)
-        assert np.isclose(ps.segment_size, segment_size)
-        assert ps.m == 2
+        assert ps.m == nseg
 
     def test_segments_with_leftover(self):
         segment_size = self.lc.tseg/2. - 1.
@@ -236,8 +240,6 @@ class TestAveragedPowerspectrum(object):
         assert AveragedPowerspectrum(nonsense_data, 10.0)
 
 
-
-
     @raises(TypeError)
     def test_init_without_segment(self):
         assert AveragedPowerspectrum(self.lc)
@@ -256,4 +258,10 @@ class TestAveragedPowerspectrum(object):
     def test_init_with_inf_segment(self):
         segment_size = np.inf
         assert AveragedPowerspectrum(self.lc, segment_size)
+
+    @raises(AssertionError)
+    def test_init_with_nan_segment(self):
+        segment_size = np.nan
+        assert AveragedPowerspectrum(self.lc, segment_size)
+
 

--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -53,6 +53,29 @@ class TestPowerspectrum(object):
         assert isinstance(ps.freq, np.ndarray)
         assert isinstance(ps.ps, np.ndarray)
 
+
+    def test_init_with_lightcurve(self):
+        assert Powerspectrum(self.lc)
+
+    @raises(AssertionError)
+    def test_init_without_lightcurve(self):
+        assert Powerspectrum(self.lc.counts)
+
+    @raises(AssertionError)
+    def test_init_with_nonsense_data(self):
+        nonsense_data = [None for i in xrange(100)]
+        assert Powerspectrum(nonsense_data)
+
+    @raises(AssertionError)
+    def test_init_with_nonsense_norm(self):
+        nonsense_norm = "bla"
+        assert Powerspectrum(self.lc, norm=nonsense_norm)
+
+    @raises(AssertionError)
+    def test_init_with_wrong_norm_type(self):
+        nonsense_norm = 1.0
+        assert Powerspectrum(self.lc, norm=nonsense_norm)
+
     def test_fourier_amplitudes(self):
         """
         the integral of powers (or Riemann sum) should be close
@@ -227,19 +250,6 @@ class TestAveragedPowerspectrum(object):
         assert ps.m == 2
 
 
-    def test_init_with_lightcurve(self):
-        assert AveragedPowerspectrum(self.lc, 10.0)
-
-    @raises(AssertionError)
-    def test_init_without_lightcurve(self):
-        assert AveragedPowerspectrum(self.lc.counts, 10.0)
-
-    @raises(AssertionError)
-    def test_init_with_nonsense_data(self):
-        nonsense_data = [None for i in xrange(100)]
-        assert AveragedPowerspectrum(nonsense_data, 10.0)
-
-
     @raises(TypeError)
     def test_init_without_segment(self):
         assert AveragedPowerspectrum(self.lc)
@@ -264,4 +274,27 @@ class TestAveragedPowerspectrum(object):
         segment_size = np.nan
         assert AveragedPowerspectrum(self.lc, segment_size)
 
+
+    def test_list_of_light_curves(self):
+        n_lcs = 10
+
+        tstart = 0.0
+        tend = 1.0
+        dt = 0.0001
+
+        time = np.linspace(tstart, tend, int((tend-tstart)/dt))
+
+        mean_count_rate = 1000.0
+        mean_counts = mean_count_rate*dt
+
+        lc_all = []
+        for n in xrange(n_lcs):
+            poisson_counts = np.random.poisson(mean_counts,
+                                           size=len(time))
+
+            lc = Lightcurve(time, counts=poisson_counts)
+            lc_all.append(lc)
+
+        segment_size = 0.5
+        assert AveragedPowerspectrum(lc_all, segment_size)
 

--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -298,3 +298,28 @@ class TestAveragedPowerspectrum(object):
         segment_size = 0.5
         assert AveragedPowerspectrum(lc_all, segment_size)
 
+    @raises(AssertionError)
+    def test_list_with_nonsense_component(self):
+        n_lcs = 10
+
+        tstart = 0.0
+        tend = 1.0
+        dt = 0.0001
+
+        time = np.linspace(tstart, tend, int((tend-tstart)/dt))
+
+        mean_count_rate = 1000.0
+        mean_counts = mean_count_rate*dt
+
+        lc_all = []
+        for n in xrange(n_lcs):
+            poisson_counts = np.random.poisson(mean_counts,
+                                           size=len(time))
+
+            lc = Lightcurve(time, counts=poisson_counts)
+            lc_all.append(lc)
+
+        lc_all.append(1.0)
+        segment_size = 0.5
+
+        assert AveragedPowerspectrum(lc_all, segment_size)

--- a/tests/test_powerspectrum.py
+++ b/tests/test_powerspectrum.py
@@ -20,8 +20,6 @@ class TestPowerspectrum(object):
         poisson_counts = np.random.poisson(mean_counts,
                                            size=time.shape[0])
 
-        self.time = time
-        self.counts = poisson_counts
         self.lc = Lightcurve(time, counts=poisson_counts)
 
 
@@ -34,15 +32,6 @@ class TestPowerspectrum(object):
         assert ps.m == 1
         assert ps.n is None
 
-    def test_make_periodgram_from_arrays(self):
-        ps = Powerspectrum(time=self.time, counts=self.counts)
-        assert ps.freq is not None
-        assert ps.ps is not None
-        assert ps.df == 1.0/self.lc.tseg
-        assert ps.norm == "rms"
-        assert ps.m == 1
-        assert ps.n == self.lc.time.shape[0]
-        assert ps.nphots == np.sum(self.lc.counts)
 
     def test_make_periodogram_from_lightcurve(self):
         ps = Powerspectrum(lc=self.lc)


### PR DESCRIPTION
I wasn't happy with the way you could pass either arrays for time stamps and counts to the __init__ of Powerspectrum or a Lightcurve object, so I've removed the first opportunity and made it required to put in a Lightcurve object (it adds one line to anyone's code to do this, but makes handling within Powerspectrum much easier). 

I've also fixed some bugs in the AveragedPowerspectrum class and added a bunch of tests for both lightcurve.py and powerspectrum.py.

This should hopefully be the last structural change to Lightcurve and Powerspectrum, so that we can now build upon those two classes for further development.

Please review and comment and/or merge if you get a chance. 