### PR TITLE
Fix import call on `__init__.py`

### DIFF
--- a/stingray/__init__.py
+++ b/stingray/__init__.py
@@ -1,3 +1,3 @@
 from stingray.lightcurve import *
 from stingray.utils import *
-from powerspectrum import *
+from stingray.powerspectrum import *


### PR DESCRIPTION
fix absolute import deprecation for python 3 and 2 compatibility:
instead of  `from powerspectrum import *`, uses  `from stingray.powerspectrum import *`