### PR TITLE
Allow for count rates as input to Lightcurve class

### DIFF
--- a/stingray/lightcurve.py
+++ b/stingray/lightcurve.py
@@ -11,7 +11,7 @@ import numpy as np
 import stingray.utils as utils
 
 class Lightcurve(object):
-    def __init__(self, time, counts):
+    def __init__(self, time, counts, input_counts=True):
         """
         Make a light curve object from an array of time stamps and an
         array of counts.
@@ -26,6 +26,10 @@ class Lightcurve(object):
             bins defined in `time` (note: **not** the count rate, i.e.
             counts/second, but the counts/bin).
 
+        input_counts: bool, optional, default True
+            If True, the code assumes that the input data in 'counts'
+            is in units of counts/bin. If False, it assumes the data
+            in 'counts' is in counts/second.
 
         Attributes
         ----------
@@ -59,10 +63,16 @@ class Lightcurve(object):
                                             "your counts array!"
 
         self.time = np.asarray(time)
-        self.counts = np.asarray(counts)
-        self.ncounts = self.counts.shape[0]
         self.dt = time[1] - time[0]
-        self.countrate = self.counts/self.dt
+
+        if input_counts:
+            self.counts = np.asarray(counts)
+            self.countrate = self.counts/self.dt
+        else:
+            self.countrate = np.asarray(counts)
+            self.counts = self.countrate*self.dt
+
+        self.ncounts = self.counts.shape[0]
         self.tseg = self.time[-1] - self.time[0] + self.dt
         self.tstart = self.time[0]-0.5*self.dt
 

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -76,6 +76,13 @@ class TestLightcurve(object):
         lc = Lightcurve(times, counts)
         assert np.allclose(lc.countrate, np.zeros_like(counts)+mean_counts/dt)
 
+    def test_input_countrate(self):
+        dt = 0.5
+        mean_counts = 2.0
+        times = np.arange(0+dt/2.,5-dt/2., dt)
+        countrate = np.zeros_like(times) + mean_counts
+        lc = Lightcurve(times, countrate, input_counts=False)
+        assert np.allclose(lc.counts, np.zeros_like(countrate)+mean_counts*dt)
 
     @raises(TypeError)
     def test_init_with_none_data(self):


### PR DESCRIPTION
I wrote a small fix that allows for inputting count rates (counts/second) into the Lightcurve class definition instead of counts/bin as is the default now. All it does is add a bool keyword `input_counts` that is True by default (input counts/bin). Setting this keyword to False implies that the array in `counts` is in units of counts/second.

Pull request includes changes to documentation and a test.